### PR TITLE
Minimum Node LTS (16)

### DIFF
--- a/.github/workflows/falkor-bundler-develop.yml
+++ b/.github/workflows/falkor-bundler-develop.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
 
     runs-on: ubuntu-latest
 
@@ -45,10 +45,10 @@ jobs:
         run: |-
           npm run release
 
-      - name: Use Pandoc v2.16.1
+      - name: Use Pandoc v2.18
         uses: r-lib/actions/setup-pandoc@v1
         with:
-          pandoc-version: "2.16.1"
+          pandoc-version: "2.18"
 
       - name: Build Manual
         run: |-

--- a/.github/workflows/falkor-bundler-manual.yml
+++ b/.github/workflows/falkor-bundler-manual.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     runs-on: ${{ matrix.os }}
@@ -52,11 +52,11 @@ jobs:
         run: |-
           node src/index.js ${{ github.event.inputs.cli }} --input src/index.js
 
-      - name: Use Pandoc v2.16.1
+      - name: Use Pandoc v2.18
         if: ${{ matrix.os != 'windows-latest' }}
         uses: r-lib/actions/setup-pandoc@v1
         with:
-          pandoc-version: "2.16.1"
+          pandoc-version: "2.18"
 
       - name: Build Manual
         if: ${{ matrix.os != 'windows-latest' }}

--- a/.github/workflows/falkor-bundler-release.yml
+++ b/.github/workflows/falkor-bundler-release.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     runs-on: ${{ matrix.os }}
@@ -47,11 +47,11 @@ jobs:
         run: |-
           npm run release
 
-      - name: Use Pandoc v2.16.1
+      - name: Use Pandoc v2.18
         if: ${{ matrix.os != 'windows-latest' }}
         uses: r-lib/actions/setup-pandoc@v1
         with:
-          pandoc-version: "2.16.1"
+          pandoc-version: "2.18"
 
       - name: Build Manual
         if: ${{ matrix.os != 'windows-latest' }}

--- a/.github/workflows/falkor-bundler-security.yml
+++ b/.github/workflows/falkor-bundler-security.yml
@@ -24,7 +24,7 @@ jobs:
       - name: GitHub Checkout
         uses: actions/checkout@v2
 
-      - name: Analyse Project Dependencies
+      - name: Analyze Project Dependencies
         uses: snyk/actions/node@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -34,5 +34,5 @@ jobs:
         with:
           languages: javascript
 
-      - name: Analyse Project Sources
+      - name: Analyze Project Sources
         uses: github/codeql-action/analyze@v1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@falkor/falkor-bundler",
-  "version": "1.1.14",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@falkor/falkor-bundler",
-      "version": "1.1.14",
+      "version": "1.2.0",
       "funding": [
         {
           "type": "ko-fi",
@@ -50,8 +50,8 @@
         "rimraf": "3.0.2"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6"
+        "node": ">=16",
+        "npm": ">=8"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falkor/falkor-bundler",
-  "version": "1.1.14",
+  "version": "1.2.0",
   "description": "ES6 JavaScript / TypeScript bundler to be used with the Falkor Framework",
   "author": {
     "name": "Barnabas Bucsy",
@@ -57,8 +57,8 @@
     "win32"
   ],
   "engines": {
-    "node": ">=14",
-    "npm": ">=6"
+    "node": ">=16",
+    "npm": ">=8"
   },
   "scripts": {
     "debug": "rimraf .dist/**/* && node src/index.js --debug --input src/index.js",

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ Include the `@falkor/falkor-bundler` in the `package.json` file under `devDepend
 ...
   "devDependencies": {
     ...
-    "@falkor/falkor-bundler": "1.1.14"
+    "@falkor/falkor-bundler": "1.2.0"
   }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -211,4 +211,4 @@ We believe - and we hope you do too - that learning how to code, how to think, a
 
 [MIT](https://github.com/theonethread/falkor-bundler/blob/master/license.txt "Open")
 
-_©2020-2021 Barnabas Bucsy - All rights reserved._
+_©2020-2022 Barnabas Bucsy - All rights reserved._


### PR DESCRIPTION
## Description
Update minimum Node engine version to 16.

## What is the current behavior?
Minimum supported Node engine is >=14.

## What is the new behavior?
Minimum supported Node engine is >=16.

## Does this introduce a breaking change?

* [x] Yes
* [ ] No

## PR Checklist

* [x] Read the [Contribution Guidelines](https://github.com/theonethread/.github/blob/master/.github/contributing.md "Open")
* [ ] Code compiles correctly both in `debug` and `release` mode
* [x] Ensured that `npm run prepublishOnly` command generates all necessary release assets
* [x] No new compiler warnings were introduced
* [x] Extended the readme / documentation / CLI help / man file(s) (_where applicable_)
* [x] Dependent changes have been merged and published in downstream modules (_if applicable_)
* [ ] All Continuous Integration builds and security checks pass
